### PR TITLE
Ensure 00_aria.cnf changes are applied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,8 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} yobasystems/alpine-mariadb
 
 LABEL maintainer="Jamie Curnow <jc@jc21.com>"
 
-ADD 00_aria.cnf /etc/mysql/conf.d/00_aria.cnf
+# mariadb does not appear to load conf.d files by default
+#ADD 00_aria.cnf /etc/mysql/conf.d/00_aria.cnf
+
+COPY 00_aria.cnf .
+RUN cat /00_aria.cnf >> /etc/mysql/my.cnf


### PR DESCRIPTION
MariaDB does not appear to default to load files in conf.d. This change brute forces the 00_aria.cnf details into the my.cnf file.